### PR TITLE
fix(reduce): support `--map` only

### DIFF
--- a/bin/couchdb-view-tester
+++ b/bin/couchdb-view-tester
@@ -5,11 +5,11 @@ var args = require('minimist')(process.argv.slice(2))
 
 var dbUrl = args._[0]
 var map = args.map && path.resolve(process.cwd(), args.map)
-var reduce = args.reduce && {
+var reduce = args.reduce && ({
   '_sum': '_sum',
   '_count': '_count',
   '_stats': '_stats'
-}[args.reduce] || path.resolve(process.cwd(), args.reduce)
+}[args.reduce] || path.resolve(process.cwd(), args.reduce))
 var watch = args.watch
 var main = require('../index')
 


### PR DESCRIPTION
Currently if you omit the `--reduce` argument, the script fails with:

``` bash
throw new TypeError('Arguments to path.resolve must be strings');
```

This fixes that.
